### PR TITLE
Bump v0.1.10 policy version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,7 +445,7 @@ dependencies = [
 
 [[package]]
 name = "psp-allowed-fsgroups"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp-allowed-fsgroups"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["Rafael Fernández López <ereslibre@ereslibre.es>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,29 +4,29 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.9
+version: 0.1.10
 name: allowed-fsgroups-psp
 displayName: Allowed Fs Groups PSP
-createdAt: 2023-03-24T15:53:25.179748771Z
+createdAt: 2023-07-07T17:42:12.88826776Z
 description: Replacement for the Kubernetes Pod Security Policy that controls the usage of fsGroups in the pod security context
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/allowed-fsgroups-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/allowed-fsgroups-psp:v0.1.9
+  image: ghcr.io/kubewarden/policies/allowed-fsgroups-psp:v0.1.10
 keywords:
 - psp
 - container
 - runtime
 links:
 - name: policy
-  url: https://github.com/kubewarden/allowed-fsgroups-psp-policy/releases/download/v0.1.9/policy.wasm
+  url: https://github.com/kubewarden/allowed-fsgroups-psp-policy/releases/download/v0.1.10/policy.wasm
 - name: source
   url: https://github.com/kubewarden/allowed-fsgroups-psp-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/allowed-fsgroups-psp:v0.1.9
+  kwctl pull ghcr.io/kubewarden/policies/allowed-fsgroups-psp:v0.1.10
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
## Description

Updates the Cargo and artifacthub files bumping the policy version to v0.1.10.

Related to https://github.com/kubewarden/kubewarden-controller/issues/479